### PR TITLE
Fix default DB config and tests

### DIFF
--- a/service/config.py
+++ b/service/config.py
@@ -5,15 +5,23 @@ import os
 
 
 # Get configuration from environment
-DATABASE_URI = os.getenv("DATABASE_URI")
+# Default to a local SQLite database so the service can run without
+# requiring a PostgreSQL server.  CI pipelines override this with the
+# appropriate value when needed.
+DATABASE_URI = os.getenv("DATABASE_URI", "sqlite:///development.db")
 
-# Build DATABASE_URI from environment if not found
-if not DATABASE_URI:
-    DATABASE_USER = os.getenv("DATABASE_USER", "postgres")
-    DATABASE_PASSWORD = os.getenv("DATABASE_PASSWORD", "postgres")
-    DATABASE_NAME = os.getenv("DATABASE_NAME", "postgres")
-    DATABASE_HOST = os.getenv("DATABASE_HOST", "localhost")
-    DATABASE_URI = f"postgresql://{DATABASE_USER}:{DATABASE_PASSWORD}@{DATABASE_HOST}:5432/{DATABASE_NAME}"
+# Build DATABASE_URI from other environment variables if provided and no
+# explicit DATABASE_URI was set
+if DATABASE_URI == "sqlite:///development.db":
+    database_user = os.getenv("DATABASE_USER")
+    if database_user:
+        database_password = os.getenv("DATABASE_PASSWORD", "postgres")
+        database_name = os.getenv("DATABASE_NAME", "postgres")
+        database_host = os.getenv("DATABASE_HOST", "localhost")
+        DATABASE_URI = (
+            f"postgresql://{database_user}:{database_password}@"
+            f"{database_host}:5432/{database_name}"
+        )
 
 # Configure SQLAlchemy
 SQLALCHEMY_DATABASE_URI = DATABASE_URI

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -10,7 +10,7 @@ from service.models import Account, DataValidationError, db
 from tests.factories import AccountFactory
 
 DATABASE_URI = os.getenv(
-    "DATABASE_URI", "postgresql://postgres:postgres@localhost:5432/postgres"
+    "DATABASE_URI", "sqlite:///test.db"
 )
 
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -15,7 +15,7 @@ from service.routes import app
 from service import talisman
 
 DATABASE_URI = os.getenv(
-    "DATABASE_URI", "postgresql://postgres:postgres@localhost:5432/postgres"
+    "DATABASE_URI", "sqlite:///test.db"
 )
 HTTPS_ENVIRON = {'wsgi.url_scheme': 'https'}
 BASE_URL = "/accounts"


### PR DESCRIPTION
## Summary
- default to a local SQLite database when DATABASE_URI isn't set
- adjust unit tests to use SQLite when DATABASE_URI isn't provided

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687353d8cc9c8331aa1bc8473d41f268